### PR TITLE
港府网站木得CF了，现更换成cloudflare.net。顺便增加Discord的直连。

### DIFF
--- a/发行版/default.conf
+++ b/发行版/default.conf
@@ -4,9 +4,18 @@ ttl=12
 mss=512
 method=w-md5
 server=8.8.8.8:53
-cfanycast=www.who.int,www.gov.hk,fbi.gov,www.ietf.org
+cfanycast=www.who.int,cloudflare.net,fbi.gov,www.ietf.org
 hmoegirl.com=[cfanycast]
 .hmoegirl.com=[cfanycast]
+
+#Discord
+.discordapp.com=[cfanycast]
+discord.com=[cfanycast]
+.discord.com=[cfanycast]
+dl.discordapp.net=[cfanycast]
+images-ext-2.discordapp.net=[cfanycast]
+images-ext-1.discordapp.net=[cfanycast]
+media.discordapp.net=[cfanycast]
 
 #NAT64
 #IPv4=2001:67c:27e4:64::


### PR DESCRIPTION
我有一个问题，就是Tcpionner用不了，无法获取DNS解析结果，以前还可以用的，不知为什么
https://s3-ap-northeast-1.amazonaws.com/s3.livere.com/202255/29255-1p8hp62.pd5nl.png
图片链接，我的邮箱:mike.yann@yandex.com，期望解决（）