### PR TITLE
Fix Github

### DIFF
--- a/发行版/default.conf
+++ b/发行版/default.conf
@@ -32,7 +32,6 @@ ipv6=false
 method=w-md5
 github.com
 .github.com
-method=w-md5,filter
 githubusercontent.com
 .githubusercontent.com
 githubassets.com


### PR DESCRIPTION
如果不删掉这一行，下面的几个域名似乎就无法连接了。典型的例子是下载最新的发行版，会提示找不到`objects.githubusercontent.com`的服务器。不知道是不是个例。