### PR TITLE
添加 Flickr

### DIFF
--- a/release/default.conf
+++ b/release/default.conf
@@ -208,6 +208,10 @@ jsdelivr.com
 jsdelivr.net
 .jsdelivr.net
 
+#Flickr
+flickr.com
+.flickr.com
+
 #You don't need sniproxy if have ipv6
 .googlevideo.com=[sniproxy]
 


### PR DESCRIPTION
由于Flickr是图片共享网站，因此，有时候会通过该平台进行相关图片的分享，或者可以从该平台上获取一些图片，与H萌娘有一定的联系。我认为应该添加Flickr